### PR TITLE
Job,Application Entity에 생성 및 수정 일자 칼럼 추가

### DIFF
--- a/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
+++ b/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
@@ -42,13 +42,13 @@ public class Application {
     private LocalDateTime updatedAt;
 
     @PrePersist
-    public void onCreated() {
+    protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
     @PreUpdate
-    public void onUpdated() {
+    protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
+++ b/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
@@ -8,6 +8,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "applications")
 @Getter
@@ -34,4 +36,8 @@ public class Application {
     @Column(name = "status", length = 20, nullable = false)
     @Enumerated(EnumType.STRING)
     private ApplicationStatus status;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
 }

--- a/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
+++ b/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
@@ -37,7 +37,18 @@ public class Application {
     @Enumerated(EnumType.STRING)
     private ApplicationStatus status;
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime createdAt;
     @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt = LocalDateTime.now();
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreated() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdated() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
+++ b/src/main/java/com/adhd/jova_v2/global/applications/entity/Application.java
@@ -6,10 +6,7 @@ import com.adhd.jova_v2.global.majors.entity.Major;
 import com.adhd.jova_v2.global.users.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "applications")
@@ -21,6 +18,7 @@ public class Application {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_id", nullable = false)
     private Job job;
@@ -36,8 +34,4 @@ public class Application {
     @Column(name = "status", length = 20, nullable = false)
     @Enumerated(EnumType.STRING)
     private ApplicationStatus status;
-
-    public void setJob(Job job) {
-        this.job = job;
-    }
 }

--- a/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
+++ b/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
@@ -48,9 +48,9 @@ public class Job {
     )
     private List<Major> requiredMajors = new ArrayList<>();
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime createdAt;
     @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt = LocalDateTime.now();
+    private LocalDateTime updatedAt;
 
     public void addApplication(Application application) {
         this.applications.add(application);
@@ -70,5 +70,16 @@ public class Job {
     public void removeRequiredMajor(Major major) {
         this.requiredMajors.remove(major);
         major.removeJob(this);
+    }
+
+    @PrePersist
+    public void onCreated() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdated() {
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
+++ b/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
@@ -73,13 +73,13 @@ public class Job {
     }
 
     @PrePersist
-    public void onCreated() {
+    protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
     @PreUpdate
-    public void onUpdated() {
+    protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
+++ b/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
@@ -6,10 +6,7 @@ import com.adhd.jova_v2.global.majors.entity.Major;
 import com.adhd.jova_v2.global.users.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
@@ -27,6 +24,7 @@ public class Job {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -70,7 +68,4 @@ public class Job {
         major.removeJob(this);
     }
 
-    public void setUser(User user) {
-        this.user = user;
-    }
 }

--- a/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
+++ b/src/main/java/com/adhd/jova_v2/global/jobs/entity/Job.java
@@ -47,6 +47,10 @@ public class Job {
             inverseJoinColumns = @JoinColumn(name = "major_id")
     )
     private List<Major> requiredMajors = new ArrayList<>();
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
 
     public void addApplication(Application application) {
         this.applications.add(application);
@@ -67,5 +71,4 @@ public class Job {
         this.requiredMajors.remove(major);
         major.removeJob(this);
     }
-
 }

--- a/src/main/java/com/adhd/jova_v2/global/majors/entity/Major.java
+++ b/src/main/java/com/adhd/jova_v2/global/majors/entity/Major.java
@@ -27,11 +27,9 @@ public class Major {
 
     public void addJob(Job job) {
         this.jobs.add(job);
-        job.getRequiredMajors().add(this);
     }
 
     public void removeJob(Job job) {
         this.jobs.remove(job);
-        job.getRequiredMajors().remove(this);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성하세요. -->
- Fixes: #5

## ✨ 작업 내용
<!-- 이 PR에서 작업한 내용을 간략히 설명하세요. -->
- [x] Application Entity에 ``createdAt``,``updatedAt`` 칼럼 추가
- [x] Job Entity에 ``createdAt``,``updatedAt`` 칼럼 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 애플리케이션 및 작업 엔티티에 생성 및 업데이트 타임스탬프 추가
  - Lombok의 `@Setter` 어노테이션을 사용하여 필드 설정 간소화

- **개선 사항**
  - 엔티티의 필드 관리 방식 최적화
  - 객체 생성 및 수정 시간 자동 추적 기능 구현
  - 사용자 정의 설정 메서드 제거 및 자동 생성된 설정 메서드 사용
  - 전공과 작업 간의 관계 관리 방식 단순화 (단방향 관계로 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->